### PR TITLE
refactor(chart): change chart name to devintent-verdaccio-gke-charts

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight, private NPM proxy registry for GKE
-name: verdaccio-gke-charts
-version: 0.4.0
+name: devintent-verdaccio-gke-charts
+version: 0.5.0
 appVersion: 5.24.1
 home: https://devintent.github.io/verdaccio-gke-charts/
 icon: https://cdn.verdaccio.dev/logos/default.png


### PR DESCRIPTION
The reason for the change is that the helm repo `verdaccio-gke-charts/devintent-verdaccio-gke-charts` is automatically added according to the generated [gh-pages](https://devintent.github.io/verdaccio-gke-charts)